### PR TITLE
[ADD] hr_utilization_analysis: planned hours measure

### DIFF
--- a/hr_utilization_analysis/report/hr_utilization_analysis.py
+++ b/hr_utilization_analysis/report/hr_utilization_analysis.py
@@ -132,7 +132,7 @@ class HrUtilizationAnalysis(models.TransientModel):
                         "amount": amount,
                         "difference": capacity - amount,
                         "planned_amount": planned_hours,
-                        "planned_difference": planned_difference - capacity,
+                        "planned_difference": capacity - planned_hours,
                     }
                 )
 

--- a/hr_utilization_analysis/report/hr_utilization_analysis.py
+++ b/hr_utilization_analysis/report/hr_utilization_analysis.py
@@ -59,10 +59,14 @@ class HrUtilizationAnalysis(models.TransientModel):
                 dates.append(date)
                 date += one_day
 
-            analysis.entry_ids = [
-                (5, False, False),
-                *[(0, False, d) for d in self._get_entry_values(employee_ids, dates)],
-            ]
+            with self.env.norecompute():
+                analysis.entry_ids = [
+                    (5, False, False),
+                    *[
+                        (0, False, d)
+                        for d in self._get_entry_values(employee_ids, dates)
+                    ],
+                ]
 
     def _get_entry_values(self, employees, dates):
         Module = self.env["ir.module.module"]
@@ -76,7 +80,7 @@ class HrUtilizationAnalysis(models.TransientModel):
 
         uom_hour = self.env.ref("uom.product_uom_hour")
 
-        all_line_ids = AccountAnalyticLine.search(
+        all_lines = AccountAnalyticLine.search(
             [
                 ("project_id", "!=", False),
                 ("employee_id", "in", employees.ids),
@@ -102,7 +106,7 @@ class HrUtilizationAnalysis(models.TransientModel):
                 leaves_by_date = {leave[0]: leave[1] for leave in leaves}
 
             for date in dates:
-                line_ids = all_line_ids.filtered(
+                lines = all_lines.filtered(
                     lambda l: l.employee_id == employee and l.date == date
                 )
 
@@ -118,16 +122,17 @@ class HrUtilizationAnalysis(models.TransientModel):
                 planned_hours = sum(tasks.mapped("planned_hours"))
 
                 amount = 0.0
-                for line_id in line_ids:
-                    amount += line_id.product_uom_id._compute_quantity(
-                        line_id.unit_amount, uom_hour
+                for line in lines:
+                    amount += line.product_uom_id._compute_quantity(
+                        line.unit_amount, uom_hour
                     )
 
                 entries.append(
                     {
                         "employee_id": employee.id,
                         "date": date,
-                        "line_ids": [(4, _id) for _id in line_ids.ids],
+                        "line_ids": [(4, _id) for _id in lines.ids],
+                        "task_ids": [(4, _id) for _id in tasks.ids],
                         "capacity": capacity,
                         "amount": amount,
                         "difference": capacity - amount,
@@ -159,6 +164,7 @@ class HrUtilizationAnalysis(models.TransientModel):
 class HrUtilizationAnalysisEntry(models.TransientModel):
     _name = "hr.utilization.analysis.entry"
     _description = "HR Utilization Analysis entry"
+    _rec_name = "entry_name"
 
     analysis_id = fields.Many2one(
         string="Analysis",
@@ -166,6 +172,7 @@ class HrUtilizationAnalysisEntry(models.TransientModel):
         required=True,
         ondelete="cascade",
     )
+    entry_name = fields.Char(compute="_compute_entry_name")
     name = fields.Char(related="employee_id.name", store=True)
     employee_id = fields.Many2one(
         string="Employee", comodel_name="hr.employee", required=True,
@@ -186,12 +193,17 @@ class HrUtilizationAnalysisEntry(models.TransientModel):
     line_ids = fields.Many2many(
         string="Timesheet Lines", comodel_name="account.analytic.line",
     )
+    task_ids = fields.Many2many(string="Planned tasks", comodel_name="project.task",)
 
     capacity = fields.Float()
     amount = fields.Float(string="Real")
     difference = fields.Float(string="Capacity remaining")
-    planned_amount = fields.Float(string="Planned")
-    planned_difference = fields.Float(string="Still to plan")
+    planned_amount = fields.Float(
+        string="Planned", compute="_compute_planned_amount", store=True
+    )
+    planned_difference = fields.Float(
+        string="Still to plan", compute="_compute_planned_amount", store=True
+    )
 
     _sql_constraints = [
         (
@@ -200,3 +212,14 @@ class HrUtilizationAnalysisEntry(models.TransientModel):
             "An analysis entry for employee/date pair has to be unique!",
         ),
     ]
+
+    @api.depends("task_ids.planned_hours")
+    def _compute_planned_amount(self):
+        for entry in self:
+            entry.planned_amount = sum(entry.task_ids.mapped("planned_hours"))
+            entry.planned_difference = entry.capacity - entry.planned_amount
+
+    @api.depends("name", "date")
+    def _compute_entry_name(self):
+        for entry in self:
+            entry.entry_name = "{} {}".format(entry.name, entry.date)

--- a/hr_utilization_analysis/report/hr_utilization_analysis.xml
+++ b/hr_utilization_analysis/report/hr_utilization_analysis.xml
@@ -18,6 +18,8 @@
                         <field name="capacity" widget="timesheet_uom" />
                         <field name="amount" widget="timesheet_uom" />
                         <field name="difference" widget="timesheet_uom" />
+                        <field name="planned_amount" widget="timesheet_uom" />
+                        <field name="planned_difference" widget="timesheet_uom" />
                     </group>
                 </group>
                 <group string="Timesheet Lines">
@@ -38,7 +40,17 @@
                 <field
                     name="difference"
                     widget="timesheet_uom"
-                    sum="Total Difference"
+                    sum="Total Remaining Capacity"
+                />
+                <field
+                    name="planned_amount"
+                    widget="timesheet_uom"
+                    sum="Total Amount"
+                />
+                <field
+                    name="planned_difference"
+                    widget="timesheet_uom"
+                    sum="Total Still Plannable"
                 />
             </tree>
         </field>
@@ -52,7 +64,18 @@
                 <field name="date" type="col" />
                 <field name="capacity" type="measure" widget="timesheet_uom" />
                 <field name="amount" type="measure" widget="timesheet_uom" />
-                <field name="difference" type="measure" widget="timesheet_uom" />
+                <field
+                    name="difference"
+                    string="Remaining"
+                    type="measure"
+                    widget="timesheet_uom"
+                />
+                <field name="planned_amount" type="measure" widget="timesheet_uom" />
+                <field
+                    name="planned_difference"
+                    type="measure"
+                    widget="timesheet_uom"
+                />
             </pivot>
         </field>
     </record>
@@ -66,6 +89,8 @@
                 <field name="capacity" type="measure" />
                 <field name="amount" type="measure" />
                 <field name="difference" type="measure" />
+                <field name="planned_amount" type="measure" />
+                <field name="planned_difference" type="measure" />
             </graph>
         </field>
     </record>

--- a/hr_utilization_analysis/report/hr_utilization_analysis.xml
+++ b/hr_utilization_analysis/report/hr_utilization_analysis.xml
@@ -22,6 +22,9 @@
                         <field name="planned_difference" widget="timesheet_uom" />
                     </group>
                 </group>
+                <group string="Tasks">
+                    <field name="task_ids" nolabel="1" />
+                </group>
                 <group string="Timesheet Lines">
                     <field name="line_ids" nolabel="1" />
                 </group>


### PR DESCRIPTION
This adds a measure for 'planned hours'. All hours of a task are measure to be at 'date_assign' of the task, this is how stock Odoo 13.0 works, ... but we could make this overridable to fix it when a proper community task scheduling / forecasting module appears.